### PR TITLE
fix(aws-lambda-nodejs): bump bun to 1.2.23 for ARM64 support

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile
+++ b/packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install --global yarn@1.22.5
 RUN npm install --global pnpm@7.33.7
 
 # Install bun
-RUN npm install --global bun@1.1.30
+RUN npm install --global bun@1.2.23
 
 # Install typescript
 RUN npm install --global typescript


### PR DESCRIPTION
## Description

Fixes Docker bundling failures when using bun on ARM64 architectures (AWS Graviton instances) by bumping bun from 1.1.30 to 1.2.23.

### Problem
The current Dockerfile uses `npm install --global bun@1.1.30` which fails on ARM64 because version 1.1.30 is missing the `@oven/bun-linux-aarch64` package needed for ARM64 architecture.

Error from issue #35534:
```
npm error Failed to find package "@oven/bun-linux-x64-baseline"
```

### Solution
Upgrade to bun@1.2.23, which includes proper ARM64 support via the `@oven/bun-linux-aarch64` optional dependency.

This is a simpler fix than the originally proposed solution of changing the installation method to use curl, as it:
- Maintains consistency with existing npm-based installation approach
- Reduces supply chain risk by not adding an additional external dependency (bun.sh installer)
- Only requires a version bump

### Verified ARM64 Support
```bash
$ npm view bun@1.2.23 optionalDependencies
{
  "@oven/bun-linux-aarch64": "1.2.23",
  "@oven/bun-linux-aarch64-musl": "1.2.23",
  ...
}
```

### Changes
- Bump bun version from 1.1.30 to 1.2.23 in `packages/aws-cdk-lib/aws-lambda-nodejs/lib/Dockerfile`

### Testing
- ✅ Verified bun@1.2.23 includes ARM64 packages
- Maintains compatibility with existing x64 builds

Closes #35534

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*